### PR TITLE
Fix broken anchor links AB#285

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -62,7 +62,7 @@ Example: `/api/v1/anyquiz/read/apple?param1=val1&param2=val2`
 
 * [apiVersion](#params-api-version)
 
-#### [apiVersion](#params-api-version)
+#### [Params API Version](#params-api-version)
 
 Parameter: `apiVersion={major.minor.patch}:` where major.minor.patch denotes the minimum required version for the API that this query should be processed by. This parameter can be used to ensure the query won't be run by a version earlier than the one specified
 
@@ -92,7 +92,7 @@ Note, each collection is versioned independently of each other, and thus version
 
 A note about API versions below 1, such as 0.1.0. These versions are under development, and thus breaking changes may be made. Once the API reaches version 1, no breaking changes will be made, only non-breaking fixes and new features will be added. Version 0 APIs are served under the "v1" url path.
 
-### [Gateway Service API](#api-spec-gateway)
+### [Gateway Service API](#gateway-service-api)
 
 [Version 1](./v1/gateway)
 
@@ -104,6 +104,6 @@ A note about API versions below 1, such as 0.1.0. These versions are under devel
 
 [Gateway Service API - Current](./../gateway/gateway-service-api.yaml)
 
-### [AnyQuiz Service API](#api-spec-anyquiz)
+### [AnyQuiz Service API](#anyquzi-service-api)
 
 * 0.0.0 - [API Specification](./v1/anyquiz/0.1.0.yaml) | [API Documentation](./v1/anyquiz/0.1.0.html) THIS IS A PLACEHOLDER

--- a/database/redis/README.md
+++ b/database/redis/README.md
@@ -8,21 +8,21 @@ This directory contains the code used to manage the redis instances used by the 
 
 * [Setup](#setup)
 
-* [Start Server Locally](#start-local)
+* [Start Server Locally](#start-server-locally)
 
-  * [Start with Script](#start-local-script)
+  * [Start with Script](#start-with-script)
 
-  * [PowerShell](#local-script-powershell)
+    * [PowerShell](#powershell)
 
 ## [Getting Started](#getting-started)
 
 ## [Setup](#setup)
 
-## [Start Server Locally](#start-local)
+## [Start Server Locally](#start-server-locally)
 
-### [Start with Script](#start-local-script)
+### [Start with Script](#start-with-script)
 
-#### [PowerShell](#local-script-powershell)
+#### [PowerShell](#powershell)
 
 The PowerShell script, [localStartExample.ps1](./localStartExample.ps1) will run a default redis server container. This script has several command line options which allow you to customize the instance.
 

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -10,23 +10,23 @@ The API Gateway service serves as the primary entry point for the Perceptia appl
 
 * [Structure](#structure)
 
-  * [Config and Setup Files](#structure-files)
+  * [Config and Setup Files](#config-and-setup-files)
 
-  * [Gateway Source](#structure-gateway-source)
+  * [Gateway Source](#gateway-source)
 
 * [Setup Server](#setup-server)
 
-  * [Building the Image](#setup-server-build-image)
+  * [Building the Image](#building-the-image)
 
-  * [Custom Image](#setup-server-custom-image)
+  * [Custom Image](#custom-image)
 
-    * [Image Specific Options](#custom-image-specific-options)
+    * [Image Specific Options](#image-specific-options)
 
-* [Start Server Locally](#start-local)
+* [Start Server Locally](#start-server-locally)
 
-  * [Start with Script](#start-local-script)
+  * [Start with Script](#start-with-script)
 
-  * [Start with Docker Commands](#start-local-docker-commands)
+  * [Start with Docker Commands](#start-with-docker-commands)
 
 * [Testing](#testing)
   
@@ -38,7 +38,7 @@ The Gateway service is designed to run within a linux container. This README wil
 
 The root of the gateway directory contains the supporting files for building the application.
 
-### [Config and Setup Files](#structure-files)
+### [Config and Setup Files](#config-and-setup-files)
 
 [Dockerfile:](./Dockerfile) multi-stage docker file to build the gateway executable and the gateway image
 
@@ -52,7 +52,7 @@ The root of the gateway directory contains the supporting files for building the
 
 [testGatewayUnit.ps1:](./testGatewayUnit.ps1) is meant for runing the gateway unit tests locally with coverage
 
-### [Gateway Source](#structure-gateway-source)
+### [Gateway Source](#gateway-source)
 
 The [gateway](./gateway/) directory contains the source files for the gateway executable.
 
@@ -66,13 +66,13 @@ The [gateway](./gateway/) directory contains the source files for the gateway ex
 
 The gateway executable is designed to be deployed using a linux container. The following subsections explain how this container is built and how to use it. The gateway executable is currently built on the [GoLang](https://hub.docker.com/_/golang) image `golang:1.12`, and the gateway image is then based off the [Alpine Linux](https://hub.docker.com/_/alpine) image `alpine:3.9`.
 
-### [Building the Image](#setup-server-build-image)
+### [Building the Image](#building-the-image)
 
 Builds of this container image are automatically triggered by pushes to the GitHub repository.
 
 Builds are tagged based on the version of the API the gateway implements (as defined in an variable in the azure-pipelines.yml file in the root of this repository which should reflect the API version listed in the gateway-service-api.yaml file in this directory). For a complete description of the possible tags see the [gateway container repository](https://hub.docker.com/r/uwthalesians/gateway) on the container registry DockerHub.
 
-#### [Build](#setup-server-build-image)
+#### [Build](#build)
 
 The image can be built locally using the docker build command. This command should be run from this directory (where the Dockerfile is located). See the local start script for an automated build and run.
 
@@ -86,13 +86,13 @@ Commands:
 
   `.` the final period in the command indicates the root directory to send to the docker deamon for the build process, this should be the directory where the Dockerfile is located
 
-### [Custom Image](#setup-server-custom-image)
+### [Custom Image](#custom-image)
 
 The Gateway image will be used during development and production. Information about this custom image can be found in the Thalesians container registry on DockerHub [uwthalesians/gateway](https://hub.docker.com/r/uwthalesians/gateway).
 
 Please refer to the description on the [container registry](https://hub.docker.com/r/uwthalesians/gateway) for specifics on how to configure it. The information below only provides an exmaple setup.
 
-#### [Image Specific Options](#custom-image-specific-options)
+#### [Image Specific Options](#image-specific-options)
 
 This section list any configuration options for the custom image.
 
@@ -128,11 +128,11 @@ Use the following variables to configure the gateway for the given environment.
 
 `REDIS_ADDRESS=<hostname:port>` (REQUIRED) the hostname and port the redis server is listening on
 
-## [Start Server Locally](#start-local)
+## [Start Server Locally](#start-server-locally)
 
 This setup explains how to build and start the server locally.
 
-### [Start with Script](#start-local-script)
+### [Start with Script](#start-with-script)
 
 Building and starting the gateway container locally can be more involed than running one script. The following must be setup:
 
@@ -194,9 +194,9 @@ Run: `.\locaStartExample.ps1 -KeepMsSqlDb -KeepRedisDb`
 
 `-BuildGateway` (switch) will build the gateway using the local source, default is: false. To set true, include the switch
 
-### [Start with Docker Commands](#start-local-docker-commands)
+### [Start with Docker Commands](#start-with-docker-commands)
 
-For directions to start the container locally using a script, see [Start Server Locally](#start-local).
+For directions to start the container locally using a script, see [Start Server Locally](#start-server-locally).
 
 1. pull the image from docker (check [registry](https://hub.docker.com/r/uwthalesians/gateway) for latest images)
 


### PR DESCRIPTION
Hotfix to updated anchor tags to match text of heading (markdown creates anchor tags for headings in its own way not using link syntax in heading. 
Should fix all broken links in READMEs for root, infrastructure, api, databases, redis and mssql, gateway.

No review necessary.