### PR TITLE
Feature: Add build pipeline for aqrest, aqmysql, aqsolr

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The Perceptia application's backend is developed using a microservices architect
 
 [./api/](./api/) contains the API specifications for the various Perceptia services
 
+[./REST/](./REST/) contains the source files for the aqrest service for the application
+
+[./content-analysis/](./content-analysis/) contains the source files for the aqsolr service for the application
+
 [./azure-pipelines.yml](./azure-pipelines.yml) which defines the continuous integration pipeline for the application, including automated testing and artifact building
 
 [./.gitignore](./gitignore) configures git to ignore certain files and not check them into the repository

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,12 +22,12 @@ variables:
     value: '$(DockerHubOrg)/$(AqrestImageName)'
   # Aqmysql Variables
   - name: AqmysqlVersion
-    value: '1.1.0'
+    value: '1.0.0'
   - name: AqmysqlImageQualified
     value: '$(DockerHubOrg)/$(AqmysqlImageName)'
   # Aqsolr Variables
-  - name: AqmysqlVersion
-    value: '1.1.0'
+  - name: AqsolrVersion
+    value: '1.0.0'
   - name: AqsolrImageQualified
     value: '$(DockerHubOrg)/$(AqsolrImageName)'
   
@@ -152,6 +152,31 @@ jobs:
   - template: './infrastructure/azp/template/step/dockerStandardTagPush.yml'
     parameters:
       qualifiedImageName: $(AqrestImageQualified)
+      versionLatestBranchTag: $(ImageTagVersionLatestBranch)
+      versionBuildIdBranchTag: $(ImageTagVersionBuildIdBranch)
+      versionTag: $(ImageTagVersion)
+      versionBuildIdTag: $(ImageTagVersionBuildId)
+      tagProduction: or(eq(variables[ 'productionTags'], 'true'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/master/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
+- job: 'BuildAqmysqlImage'
+  variables:
+  - name: ImageTagVersion
+    value: '$(AqmysqlImageQualified):$(AqmysqlVersion)'
+  - name: ImageTagVersionBuildId
+    value: '$(ImageTagVersion)-build-$(Build.BuildId)'
+  - name: ImageTagVersionBuildIdBranch
+    value: '$(ImageTagVersionBuildId)-branch-$(Build.SourceBranchName)'
+  - name: ImageTagVersionLatestBranch
+    value: '$(ImageTagVersion)-build-latest-branch-$(Build.SourceBranchName)'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  steps:
+  - template: './infrastructure/azp/template/step/dockerStandardBuild.yml'
+    parameters:
+      dockerFile: '$(system.defaultWorkingDirectory)/database/mysql/Dockerfile'
+      qualifiedImageName: $(AqmysqlImageQualified)
+  - template: './infrastructure/azp/template/step/dockerStandardTagPush.yml'
+    parameters:
+      qualifiedImageName: $(AqmysqlImageQualified)
       versionLatestBranchTag: $(ImageTagVersionLatestBranch)
       versionBuildIdBranchTag: $(ImageTagVersionBuildIdBranch)
       versionTag: $(ImageTagVersion)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,3 +182,28 @@ jobs:
       versionTag: $(ImageTagVersion)
       versionBuildIdTag: $(ImageTagVersionBuildId)
       tagProduction: or(eq(variables[ 'productionTags'], 'true'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/master/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
+- job: 'BuildAqsolrImage'
+  variables:
+  - name: ImageTagVersion
+    value: '$(AqsolrImageQualified):$(AqsolrVersion)'
+  - name: ImageTagVersionBuildId
+    value: '$(ImageTagVersion)-build-$(Build.BuildId)'
+  - name: ImageTagVersionBuildIdBranch
+    value: '$(ImageTagVersionBuildId)-branch-$(Build.SourceBranchName)'
+  - name: ImageTagVersionLatestBranch
+    value: '$(ImageTagVersion)-build-latest-branch-$(Build.SourceBranchName)'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  steps:
+  - template: './infrastructure/azp/template/step/dockerStandardBuild.yml'
+    parameters:
+      dockerFile: '$(system.defaultWorkingDirectory)/content-analysis/Dockerfile'
+      qualifiedImageName: $(AqsolrImageQualified)
+  - template: './infrastructure/azp/template/step/dockerStandardTagPush.yml'
+    parameters:
+      qualifiedImageName: $(AqsolrImageQualified)
+      versionLatestBranchTag: $(ImageTagVersionLatestBranch)
+      versionBuildIdBranchTag: $(ImageTagVersionBuildIdBranch)
+      versionTag: $(ImageTagVersion)
+      versionBuildIdTag: $(ImageTagVersionBuildId)
+      tagProduction: or(eq(variables[ 'productionTags'], 'true'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/master/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,21 @@ variables:
     value: '0.7.1'
   - name: MssqlImageQualified
     value: '$(DockerHubOrg)/$(MssqlImageName)'
+  # Aqrest Variables
+  - name: AqrestVersion
+    value: '1.1.0'
+  - name: AqrestImageQualified
+    value: '$(DockerHubOrg)/$(AqrestImageName)'
+  # Aqmysql Variables
+  - name: AqmysqlVersion
+    value: '1.1.0'
+  - name: AqmysqlImageQualified
+    value: '$(DockerHubOrg)/$(AqmysqlImageName)'
+  # Aqsolr Variables
+  - name: AqmysqlVersion
+    value: '1.1.0'
+  - name: AqsolrImageQualified
+    value: '$(DockerHubOrg)/$(AqsolrImageName)'
   
 
 trigger:
@@ -44,7 +59,7 @@ pr:
     - README.md
     - infrastructure/*
 
-jobs:
+jobs: 
 - job: 'TestGatewayUnitTests'
   variables:
     GOBIN:  '$(GOPATH)/bin' # Go binaries path
@@ -112,6 +127,31 @@ jobs:
   - template: 'infrastructure/azp/template/step/dockerStandardTagPush.yml'
     parameters:
       qualifiedImageName: $(MssqlImageQualified)
+      versionLatestBranchTag: $(ImageTagVersionLatestBranch)
+      versionBuildIdBranchTag: $(ImageTagVersionBuildIdBranch)
+      versionTag: $(ImageTagVersion)
+      versionBuildIdTag: $(ImageTagVersionBuildId)
+      tagProduction: or(eq(variables[ 'productionTags'], 'true'), or(startsWith(variables['Build.SourceBranch'], 'refs/heads/master/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
+- job: 'BuildAqrestImage'
+  variables:
+  - name: ImageTagVersion
+    value: '$(AqrestImageQualified):$(AqrestVersion)'
+  - name: ImageTagVersionBuildId
+    value: '$(ImageTagVersion)-build-$(Build.BuildId)'
+  - name: ImageTagVersionBuildIdBranch
+    value: '$(ImageTagVersionBuildId)-branch-$(Build.SourceBranchName)'
+  - name: ImageTagVersionLatestBranch
+    value: '$(ImageTagVersion)-build-latest-branch-$(Build.SourceBranchName)'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  steps:
+  - template: './infrastructure/azp/template/step/dockerStandardBuild.yml'
+    parameters:
+      dockerFile: '$(system.defaultWorkingDirectory)/REST/Dockerfile'
+      qualifiedImageName: $(AqrestImageQualified)
+  - template: './infrastructure/azp/template/step/dockerStandardTagPush.yml'
+    parameters:
+      qualifiedImageName: $(AqrestImageQualified)
       versionLatestBranchTag: $(ImageTagVersionLatestBranch)
       versionBuildIdBranchTag: $(ImageTagVersionBuildIdBranch)
       versionTag: $(ImageTagVersion)


### PR DESCRIPTION
# Overview

Basic build pipeline has been created for the aqrest, aqmysql, aqsolr images. Note this addition only builds the images, there are no tests defined for the images meaning the pipeline will only catch issues with building the image. The pipeline as defined will not test or detect issues with running the built container. 

## Request for Review

Nothing specific. PR will be merged by 2 pm, May 10 2019 if no review completed. 

## Future Work

Work will be continued off this branch in branch feature/peacock-local-start to create a local start script for the entire backend. 