### PR TITLE
Add variable for mssql port publish

### DIFF
--- a/infrastructure/local/localStartExample.ps1
+++ b/infrastructure/local/localStartExample.ps1
@@ -82,6 +82,7 @@ if (!$CleanUp) {
                 Write-Host "Version must be provided, but no version provided for mssql, exiting..."
                 exit(1)
         }
+        Set-Item -Path env:MSSQL_PORT_PUBLISH -Value $MsSqlPortPublish
         # Redis perceptia-stack.yml substituion variables
         Set-Item -Path env:REDIS_IMAGE_AND_TAG -Value "redis:5.0.4-alpine"
         Set-Item -Path env:REDIS_PORT_PUBLISH -Value $RedisPortPublish


### PR DESCRIPTION
# Overview

See ADO Bug 289 ([AB#289](https://dev.azure.com/uw-thalesians/61b89ca6-2c20-466e-bce7-f0b801a5d192/_workitems/edit/289)). Fixing missing variable for mssql port publish causing stack not to start.

## Request for Review

Hot fix, no review requested. Script runs successfully once variable added.