### PR TITLE
Feature: Describe Internal Communication API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -12,6 +12,8 @@ The Perceptia API is a REST based api. The purpose of this document is to define
 
 * [API Specifications](#api-specifications)
 
+* [Internal API Specifications](#internal-api-specifications)
+
 ## [Overview](#overview)
 
 The Perceptia API (API) is designed to service the Perceptia Application, which is currently being developed as a Web Application. This service, and the APIs it exposes are not intended for use by thrid-parties.
@@ -68,6 +70,12 @@ Parameter: `apiVersion={major.minor.patch}:` where major.minor.patch denotes the
 
 Example: `/api/v1/anyquiz/read/apple?apiVersion=1.0.0`
 
+#### [Params Auth Token](#params-auth-token)
+
+Parameter: `access_token={access token}:` where access token is the access token the client wants to authenticate with. Note, the client should only use this if they are unable to use the Authroization header
+
+Example: `/api/v1/anyquiz/read/apple?access_token=`
+
 ## [Making a Request](#making-a-request)
 
 The Perceptia API is available on the public internet. There is currently no access restrictions, although this may change in the future. This section will provide example requests to demonstrate how to make requests to the API.
@@ -109,3 +117,11 @@ A note about API versions below 1, such as 0.1.0. These versions are under devel
 ### [AnyQuiz Service API](#anyquiz-service-api)
 
 * 0.0.0 - [API Specification](./v1/anyquiz/0.1.0.yaml) | [API Documentation](./v1/anyquiz/0.1.0.html) THIS IS A PLACEHOLDER
+
+## [Internal API Specifications](#internal-api-specifications)
+
+The purpose of this section is to define how the api processes requests internally and how internal services communicate.
+
+### [Authentication](#authentication)
+
+The gateway service handles all authentication for the Perceptia API. For informaiton on how an API client authenticates, see the API spec for the gateway, version 0.3.0 or greater. Once the client has authenticated with the system, an authentication token is generated and returned to the client in an Authroization header. This token should then be supplied in an Authorization header on each subsequent request to authenticate the user without the user having to provide their credentials again.

--- a/api/README.md
+++ b/api/README.md
@@ -1,14 +1,18 @@
 # Perceptia API
 
-The Perceptia API is a REST based api. The purpose of this document is to define the general syntax for the API and provide references to the various API specifications that make up the Perceptia API.
+The Perceptia API is a REST based API. The purpose of this document is to define the general syntax for the API and provide references to the various API specifications that make up the Perceptia API.
 
 ## [Contents](#Contents)
 
 * [Overview](#overview)
 
-* [Syntax](#syntax)
+* [Request Syntax](#request-syntax)
+
+* [Common Request Elements](#common-request-elements)
 
 * [Making a Request](#making-a-request)
+
+* [Common Response Elements](#common-response-elements)
 
 * [API Specifications](#api-specifications)
 
@@ -22,7 +26,7 @@ The API is a REST based archetecture, with JSON as the primary format for reques
 
 Note, each services repository may contain an OpenApi Yaml file `*-api.yaml` defining the API the code implements.
 
-## [Syntax](#Syntax)
+## [Request Syntax](#request-syntax)
 
 ### [URL Syntax](#url-syntax)
 
@@ -44,11 +48,7 @@ Meanings:
 
    `queryParameters:` query parameters may be used by the collection resource and/or by the the gateway. See [API Specifications](#api-specifications) for possible parameters used by a collection
 
-### [Misc Syntax](#misc-syntax)
-
-TODO: Describe other common elements of the API's syntax (such as common headers, parameters)
-
-## [Common Elements](#common-elements)
+## [Common Request Elements](#common-request-elements)
 
 This section lists the common elements used in the API, including query parameters.
 
@@ -64,7 +64,11 @@ Example: `/api/v1/anyquiz/read/apple?param1=val1&param2=val2`
 
 * [apiVersion](#params-api-version)
 
+* [Auth Token](#params-auth-token)
+
 #### [Params API Version](#params-api-version)
+
+The apiVersion parameter can be used to indicate the minimum version required for the given api within the major version provided (meaning, if the client sends an apiVersion parameter with a value of 1.1.0, the collection requested can reply as long as it implements a version greater than 1.1.0 and less than 2.0.0, and if the client sends an apiVersion parameter with a value of 2.0.1, the collection requested can reply as long as it implements a version greater than 2.0.1 and less than 3.0.0), not all collections may use this parameter. This parameter is eqivalent to the Perceptia-Api-Version header, however only one should be set, the result is undefined if both the parameter and header are provided. The Perceptia-Api-Version header should be used instead of the query parameter.
 
 Parameter: `apiVersion={major.minor.patch}:` where major.minor.patch denotes the minimum required version for the API that this query should be processed by. This parameter can be used to ensure the query won't be run by a version earlier than the one specified
 
@@ -72,9 +76,43 @@ Example: `/api/v1/anyquiz/read/apple?apiVersion=1.0.0`
 
 #### [Params Auth Token](#params-auth-token)
 
-Parameter: `access_token={access token}:` where access token is the access token the client wants to authenticate with. Note, the client should only use this if they are unable to use the Authroization header
+Parameter: `access_token={access token}:` where access token is the access token the client wants to authenticate with. Note, the client should only use this if they are unable to use the Authroization header. The token should be escaped (BUG: this query paramter does not currently work, do not use)
 
-Example: `/api/v1/anyquiz/read/apple?access_token=`
+Example: `/api/v1/anyquiz/read/apple?access_token=-Ld3NE1g0xFiyIm70PpK8jCFC1BF0Gsc9ya6YQGYnBBWR4O-epZOmQC-3g6YpEDjF_0pvfMtPkn5UhdO8WOOFg%3D%3D`
+
+### [Headers](#headers)
+
+This subsection lists the headers that are common to all API calls. Note, headers may not be used by all API collections (in which case their inclusion will have no effect on the processing of the request)
+
+Syntax: `{Header-Key}: {header value}`
+
+Where `Header-Key:` is the header name, such as "Authorization"
+
+Example: `Header-Key: value`
+
+* [Header Api Version](#header-api-version)
+
+* [Header Authorization](#header-authorization)
+
+#### [Header API Version](#header-api-version)
+
+The Perceptia-Api-Version header can be used to indicate the minimum version required for the given api within the major version provided (meaning, if the client sends a header with a value of 1.1.0, the collection requested can reply as long as it implements a version greater than 1.1.0 and less than 2.0.0, and if the client sends a header with a value of 2.0.1, the collection requested can reply as long as it implements a version greater than 2.0.1 and less than 3.0.0), not all collections may use this header. This parameter is eqivalent to the Perceptia-Api-Version header, however only one should be set, the result is undefined if both the parameter and header are provided. The Perceptia-Api-Version header should be used instead of the query parameter.
+
+Header key: `Perceptia-Api-Version` is the header that should be set to indicate the minimum version of the collection api the request should be processed by
+
+Example: `Perceptia-Api-Version: 1.1.0`
+
+#### [Header Authorization](#header-authorization)
+
+The Authorization header is used to pass the session token that identifies the user to the system. This token can be obtained when creating a new user or starting a new session (see the gateway api spec version 0.3.0 or above for the coresponding routes). This header should be passed by the client for all requests once obtained until the token expires or the client starts a new session. Note, if it is not possible to set a header when making a request, the token can be provided in a query paramter, but that method is not reccomended.
+
+Header key: `Authorization` is the header that should be set to pass the authorization token
+
+Header value: `Bearer {access_token}` the value should start with the string "Bearer" followed by one space " " and then the value of the access token
+
+Access token: `{session token}` the access token is the session token returned by the api when creating a new user or starting a new session in the Authorization header
+
+Example: `Authorization: Bearer -Ld3NE1g0xFiyIm70PpK8jCFC1BF0Gsc9ya6YQGYnBBWR4O-epZOmQC-3g6YpEDjF_0pvfMtPkn5UhdO8WOOFg==`
 
 ## [Making a Request](#making-a-request)
 
@@ -89,6 +127,30 @@ Example request: `/api/v1/anyquiz/read/apple`
 Make request using curl: `curl -X GET "https://api.perceptia.info/api/v1/gateway/health`
 
 Example response: `{"name":"Perceptia API Health Report","version":"0.2.0","status":"ready"}`
+
+## [Common Response Elements](#common-response-elements)
+
+This section lists the common elements returned by the API, including.
+
+### [Response Headers](#response-headers)
+
+This subsection lists the headers that are common to all API responses. Note, headers may not be returned by all API collections.
+
+Syntax: `{Header-Key}: {header value}`
+
+Where `Header-Key:` is the header name, such as "Authorization"
+
+Example: `Header-Key: value`
+
+* [Response Header API Version](#response-header-api-version)
+
+#### [Response Header API Version](#response-header-api-version)
+
+The Perceptia-Api-Version header when included in a response to a client request indicates the version of the api for the given collection that processed the request and produced the response. Not all collections may return this header.
+
+Header key: `Perceptia-Api-Version` is the header that indicates the version of the collection api that processed the request and produced the response
+
+Example: `Perceptia-Api-Version: 1.1.0`
 
 ## [API Specifications](#api-specifications)
 
@@ -116,7 +178,7 @@ A note about API versions below 1, such as 0.1.0. These versions are under devel
 
 ### [AnyQuiz Service API](#anyquiz-service-api)
 
-* 0.0.0 - [API Specification](./v1/anyquiz/0.1.0.yaml) | [API Documentation](./v1/anyquiz/0.1.0.html) THIS IS A PLACEHOLDER
+* 0.0.0 - [API Specification](./v1/anyquiz/0.0.0.yaml) | [API Documentation](./v1/anyquiz/0.0.0.html) THIS IS A PLACEHOLDER
 
 ## [Internal API Specifications](#internal-api-specifications)
 
@@ -125,3 +187,27 @@ The purpose of this section is to define how the api processes requests internal
 ### [Authentication](#authentication)
 
 The gateway service handles all authentication for the Perceptia API. For informaiton on how an API client authenticates, see the API spec for the gateway, version 0.3.0 or greater. Once the client has authenticated with the system, an authentication token is generated and returned to the client in an Authroization header. This token should then be supplied in an Authorization header on each subsequent request to authenticate the user without the user having to provide their credentials again.
+
+When the gateway receives the Authentication header (or access_token query parameter), it looks up the session id in the token, if there is a valid authenticated session found the gateway will add the following header(s) to the request, which can be used by downstream services to identify a session and / or user.
+
+* [Header Perceptia-User-Uuid](#header-perceptia-user-uuid)
+
+* [Header Perceptia-Session-Uuid](#header-perceptia-session-uuid)
+
+#### [Header Perceptia-User-Uuid](#header-perceptia-user-uuid)
+
+This header is only used internally by the Perceptia service to communicate to downstream services the uuid of the authenticated user. If this header is found in a request from a user it is always removed wheather or not the user is authenticated. If the user is authenticated, the user's uuid is added as the value for the header.
+
+Header key: `Perceptia-User-Uuid` custom header
+
+Header value: `{uuid}` is the uuid (v4) of the authenticated user, matching the regex: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89aAbB][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"
+
+#### [Header Perceptia-Session-Uuid](#header-perceptia-session-uuid)
+
+**WARNING: Not Yet Implemented**
+
+This header is only used internally by the Perceptia service to communicate to downstream services the uuid of the session. If this header is found in a request from a user it is always removed wheather or not the user is in a session. If the user is in a session, the session uuid is added as the value for the header.
+
+Header key: `Perceptia-Session-Uuid` custom header
+
+Header value: `{uuid}` is the uuid (v4) of the session, matching the regex: "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89aAbB][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,7 @@ trigger:
     exclude:
     - README.md
     - infrastructure/*
+    - api/*
 
 pr:
   autoCancel: "true"


### PR DESCRIPTION
# Overview

Added "Internal API Specifications" to api/README.md file to explain the Header(s) that the gateway adds to the request for authenticated users. Updated "Common Request Elements" section to describe the Authorization header that should be used to authenticate requests and maintain session state.

## Request for Review

If anything doesn't make sense or could be stated more clearly please comment the text so I can update. 