### PR TITLE
Feature: Update local starts to use build 288

### DIFF
--- a/database/mssql/localStartExample.ps1
+++ b/database/mssql/localStartExample.ps1
@@ -6,7 +6,7 @@ Param (
     [String]$MsSqlSkipSetupIfExist = "Y",
     [String]$MsSqlSkipSetup = "N",
     [switch]$BuildMsSql,
-    [string]$MsSqlVersion = "0.8.1",
+    [string]$MsSqlVersion = "1.0.0",
     [string]$MsSqlBuild = "232",
     [string]$MsSqlBranch = "develop",
     [String]$PerceptiaDockerNet = "perceptia-net",
@@ -66,7 +66,7 @@ if (!$CleanUp) {
     Write-Host "MsSql Server is listening on the host at: localhost:${MsSqlPortPublish}"
 } else {
     docker rm --force (docker ps -aq --filter "label=label.perceptia.info/part-of=${MSSQL_SL_SERVICE_NAME}")
-    if ($MsSqlRemoveDbVolume-or $RemoveAllDbVolumes) {
+    if ($MsSqlRemoveDbVolume -or $RemoveAllDbVolumes) {
         Write-Host "MsSqlRemoveDbVolume or RemoveAllDbVolumes option true, removing previous database"
         docker volume rm $MSSQL_VOLUME_NAME
     }

--- a/infrastructure/local/README.md
+++ b/infrastructure/local/README.md
@@ -112,6 +112,8 @@ Note, you will need to create the Tls certs using the script in the encrypt dire
 
 `-RemoveAllContainers` (switch) will cause all containers used by the stack labeled as "app.perceptia.info/part-of=perceptia-api" to be deleted
 
+`-SkipImageCheck` (switch) will skip checking and pulling the images before starting the stack (note, if stack can't find images the stack will succeed but the containers won't be started because the image could not be found, so use this only if you know the branches exist)
+
 ### Docker Stack Config
 
 The docker stack config makes certain assumptions about the images being run and the local ip environemnt on the device where the script is being run.

--- a/infrastructure/local/localStartExample.ps1
+++ b/infrastructure/local/localStartExample.ps1
@@ -131,11 +131,12 @@ if (!$CleanUp) {
 
                 
         if ((docker stack ls --format "{{.Name}}") -Match $PERCEPTIA_STACK_NAME) {
+                Write-Host "`n"
                 Write-Host "Note, due to issue with bind points (see https://github.com/docker/for-win/issues/1521), must clean up stack before redeployment"
                 Write-Host "Cleaning up the docker stack: $PERCEPTIA_STACK_NAME"
                 docker stack rm $PERCEPTIA_STACK_NAME
-                Write-Host "Waiting 10 seconds to allow docker to clean up"
-                Start-Sleep -Seconds "10"
+                Write-Host "Waiting 15 seconds to allow docker to clean up"
+                Start-Sleep -Seconds "15"
         }
 
         if ($RemoveAllDbVolumes -and (((docker volume ls --format "{{.Name}}") -Match "${PERCEPTIA_STACK_NAME}"))) {
@@ -198,6 +199,8 @@ if (!$CleanUp) {
         docker stack deploy -c perceptia-stack.yml $PERCEPTIA_STACK_NAME
         if (!$?) {
                 Write-Host "Docker stack: $PERCEPTIA_STACK_NAME failed to start, see error above."
+                Write-Host "`n"
+                Write-Host "In most cases rerunning this script a second time will resolve error."
                 exit(1)
         }
         Write-Host "`n"


### PR DESCRIPTION
# Overview

Quick update to have localStartExample.ps1 scripts for ./gateway and ./infrastructure/local and ./database/mssql/ use build 288 and version 1.0.0 of gateway and mssql by default. Additionally, scripts have been fixed to check for existence of docker objects before trying to remove to prevent docker errors when trying to remove and empty string. NOTE: it is recommended that you remove existing containers/volumes created by these scripts before running them. The scripts have been updated to use docker labels to identify objects and previous versions of the script may not have used that. Easiest is to run:

     `docker rm --force (docker ps -aq)`

But if you already have a docker stack running, you will need to stop the stack first, otherwise it will keep trying to recreate the containers. 

     `docker stack rm (docker stack ls --format "{{.Name}}")`

## Request for Review

No request for review. Fixes to existing code. Will merge immediately. 